### PR TITLE
Fix TRIM of user password for authenticated SOAP calls

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,6 +6,6 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2019 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.2.0';
+    EXPORT Version := '1.2.1';
     EXPORT PlatformVersion := '6.0.0';
 END;

--- a/GenIndex.ecl
+++ b/GenIndex.ecl
@@ -68,7 +68,7 @@ EXPORT GenIndex := MODULE(DataMgmt.Common)
     SHARED CreateAuthHeaderValue(STRING username, STRING userPW) := IF
         (
             TRIM(username, ALL) != '',
-            'Basic ' + Std.Str.EncodeBase64((DATA)(TRIM(username, ALL) + ':' + TRIM(userPW, ALL))),
+            'Basic ' + Std.Str.EncodeBase64((DATA)(TRIM(username, ALL) + ':' + TRIM(userPW, LEFT, RIGHT))),
             ''
         );
 


### PR DESCRIPTION
New code trims only leading and trailing whitespace, not all whitespace.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>